### PR TITLE
Automatic dark theme

### DIFF
--- a/app/src/main/java/com/bernaferrari/sdkmonitor/MainActivity.kt
+++ b/app/src/main/java/com/bernaferrari/sdkmonitor/MainActivity.kt
@@ -1,20 +1,26 @@
 package com.bernaferrari.sdkmonitor
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.NavigationUI
 import com.bernaferrari.sdkmonitor.databinding.ActivityMainBinding
+import com.bernaferrari.sdkmonitor.extensions.isDarkMode
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        if (Injector.get().isLightTheme().get()) {
-            setTheme(R.style.AppThemeLight)
+        if (Injector.get().isLightTheme().isSet()) {
+            if (Injector.get().isLightTheme().get()) {
+                setTheme(R.style.AppThemeLight)
+            } else {
+                setTheme(R.style.AppThemeDark)
+            }
         } else {
-            setTheme(R.style.AppThemeDark)
+            setAndroidTheme()
         }
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -26,6 +32,22 @@ class MainActivity : AppCompatActivity() {
                 binding.bottomNav,
                 fragment.findNavController()
             )
+        }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        if (!Injector.get().isLightTheme().isSet()) {
+            setAndroidTheme()
+        }
+    }
+
+    private fun setAndroidTheme() {
+        if (isDarkMode) {
+            setTheme(R.style.AppThemeDark)
+        } else {
+            setTheme(R.style.AppThemeLight)
         }
     }
 }

--- a/app/src/main/java/com/bernaferrari/sdkmonitor/extensions/OtherExtensions.kt
+++ b/app/src/main/java/com/bernaferrari/sdkmonitor/extensions/OtherExtensions.kt
@@ -1,5 +1,7 @@
 package com.bernaferrari.sdkmonitor.extensions
 
+import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import androidx.annotation.ColorInt
 import androidx.core.graphics.ColorUtils
@@ -65,3 +67,7 @@ fun <A, B, R> doSwitchMap(
                                 two.invoke(a, b)
                             }
                 }
+
+val Context.isDarkMode: Boolean
+    get() = (this.resources.configuration.uiMode
+            and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES


### PR DESCRIPTION
When the SDK Monitor "Light mode" preference has not been set yet, follow Android system preference (will automatically set to Dark mode on first use if Android theme is dark, instead of Light, like it is right now)

Edit: Putting back as draft due to "Light mode" preference being enabled when system is in dark mode (should be disabled and follow system preference instead)