### PR TITLE
Fix crash when changing Order by targetSDK

### DIFF
--- a/base-android/src/main/java/com/bernaferrari/ui/search/BaseSearchFragment.kt
+++ b/base-android/src/main/java/com/bernaferrari/ui/search/BaseSearchFragment.kt
@@ -119,7 +119,7 @@ abstract class BaseSearchFragment : SharedBaseFrag(), CoroutineScope {
     abstract fun onTextChanged(searchText: String)
 
     fun setInputHint(hint: String) {
-        binding.queryInput.hint = hint
+        _binding?.queryInput?.hint = hint
     }
 
     fun getInputText(): String = binding.queryInput.text.toString()


### PR DESCRIPTION
Fix `NullPointerException` when changing the "Order by targetSDK" preference. Issue introduced in #23