### PR TITLE
Fix #28 - notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application

--- a/app/src/main/java/com/bernaferrari/sdkmonitor/SyncWorker.kt
+++ b/app/src/main/java/com/bernaferrari/sdkmonitor/SyncWorker.kt
@@ -40,7 +40,8 @@ class SyncWorker(
                 .meta {
                     this.clickIntent = PendingIntent.getActivity(
                         context, 0,
-                        Intent(context, MainActivity::class.java), 0
+                        Intent(context, MainActivity::class.java),
+                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                     )
                 }
                 .asBigText {

--- a/app/src/main/java/com/bernaferrari/sdkmonitor/core/AppManager.kt
+++ b/app/src/main/java/com/bernaferrari/sdkmonitor/core/AppManager.kt
@@ -86,7 +86,8 @@ object AppManager {
                     .meta {
                         this.clickIntent = PendingIntent.getActivity(
                             appContext, 0,
-                            Intent(appContext, MainActivity::class.java), 0
+                            Intent(appContext, MainActivity::class.java),
+                            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                         )
                     }.content {
                         title = "TargetSDK changed for ${getAppLabel(packageInfo)}!"


### PR DESCRIPTION
You still need to manually grant permission from app info on Android 13+

Having a prompt from the app itself would be an improvement, but prompting directly on first run should be avoided IMO

(Note that during my test I had to open the app to get the notification to show up, I don't know if the notification is expected at that moment, or right after the updated package is updated?)