### PR TITLE
Fix background sync dialog

### DIFF
--- a/app/src/main/java/com/bernaferrari/sdkmonitor/WorkerHelper.kt
+++ b/app/src/main/java/com/bernaferrari/sdkmonitor/WorkerHelper.kt
@@ -44,7 +44,7 @@ object WorkerHelper {
             if (constraints.charging) this.setRequiresCharging(true)
         }
 
-        val realDelay = delay.substring(1, 3).toLong()
+        val realDelay = delay.substring(1).toLong()
 
         val timeUnit = when (delay.substring(0, 1).toInt()) {
             1 -> TimeUnit.MINUTES

--- a/app/src/main/res/layout/dialog_sync.xml
+++ b/app/src/main/res/layout/dialog_sync.xml
@@ -40,7 +40,7 @@
             android:text="@string/background_sync"
             tools:text="Background Sync" />
 
-        <Switch
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/item_switch"
             android:layout_width="@dimen/avatar_bounds"
             android:layout_height="@dimen/avatar_bounds"


### PR DESCRIPTION
- Fix crash when delay is shorter than 2 characters.
- Update text when minutes/hours/days is checked or sync disabled
- Actually update preferences when there is a change
- Actually cancel work when sync is disabled

Side note: If my understanding is correct, the work is a one time job that schedules another one at the end of the process. So if that process fails, the next one will not be scheduled. Is there a reason you made it that way instead of a periodic job?