### PR TITLE
Remove kotlinCompilerExtensionVersion from build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,10 +71,6 @@ android {
         buildConfig = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.get()
-    }
-
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 activityCompose = "1.10.1"
 androidGradlePlugin = "8.10.1"
-compose = "1.8.2"
 composeBom = "2025.06.00"
 coroutines = "1.10.2"
 datastore = "1.1.7"


### PR DESCRIPTION
As the compose compiler plugin part of the kotlin repo is now used, we no longer need to specify the extension version in build scripts.